### PR TITLE
refactor: extract render helpers, narrow exception scope, add pytest-asyncio

### DIFF
--- a/cert_host_scraper/cli.py
+++ b/cert_host_scraper/cli.py
@@ -21,6 +21,28 @@ from cert_host_scraper.scraper import (
 from cert_host_scraper.utils import divide_chunks, strip_url
 
 NO_STATUS_CODE_FILTER = 0
+NO_STATUS_CODE_TIMEOUT = -1
+
+
+def _render_json_output(results: list[UrlResult]) -> str:
+    return json.dumps(
+        [{"url": r.url, "status_code": r.status_code} for r in results],
+        indent=2,
+    )
+
+
+def _render_table_output(results: list[UrlResult], console: Console) -> None:
+    table = Table(show_header=True, header_style="bold", box=box.MINIMAL)
+    table.add_column("URL")
+    table.add_column("Status Code")
+    for r in results:
+        code = str(r.status_code) if r.status_code != NO_STATUS_CODE_TIMEOUT else "-"
+        url, code_display = r.url, code
+        if r.status_code == 200:
+            code_display = f"[green]{code}[/green]"
+            url = f"[green]{url}[/green]"
+        table.add_row(url, code_display)
+    console.print(table)
 
 
 def process_urls(
@@ -150,29 +172,9 @@ def search(
         display = result.scraped
 
     if display_json:
-        json_output = [
-            {"url": url_result.url, "status_code": url_result.status_code}
-            for url_result in display
-        ]
-        click.echo(json.dumps(json_output, indent=2))
+        click.echo(_render_json_output(display))
     else:
-        table = Table(show_header=True, header_style="bold", box=box.MINIMAL)
-        table.add_column("URL")
-        table.add_column("Status Code")
-        for url_result in display:
-            display_code = str(url_result.status_code)
-            if url_result.status_code == -1:
-                display_code = "-"
-
-            url = url_result.url
-            if url_result.status_code == 200:
-                display_code = f"[green]{display_code}[/green]"
-                url = f"[green]{url}[/green]"
-
-            table.add_row(url, display_code)
-
-        console = Console()
-        console.print(table)
+        _render_table_output(display, Console())
 
 
 if __name__ == "__main__":

--- a/cert_host_scraper/scraper.py
+++ b/cert_host_scraper/scraper.py
@@ -49,7 +49,7 @@ def _default_headers() -> dict:
 def fetch_site_information(url: str, timeout: int) -> int:
     try:
         return requests.get(url, timeout=timeout).status_code
-    except Exception as e:
+    except requests.RequestException as e:
         logger.debug(e)
         return -1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ cert-host-scraper = "cert_host_scraper.cli:cli"
 [dependency-groups]
 dev = [
     "pytest>=9,<10",
+    "pytest-asyncio>=1.4.0",
     "pytest-cov>=7.0.0,<8",
     "pytest-socket>=0.7.0,<0.8",
     "vcrpy>=8.1.1,<9",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 addopts = --disable-socket --allow-unix-socket
+asyncio_mode = auto

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.10, <4"
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
 name = "cert-host-scraper"
 source = { editable = "." }
 dependencies = [
@@ -15,6 +24,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-socket" },
     { name = "vcrpy" },
@@ -31,6 +41,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=9,<10" },
+    { name = "pytest-asyncio", specifier = ">=1.4.0" },
     { name = "pytest-cov", specifier = ">=7.0.0,<8" },
     { name = "pytest-socket", specifier = ">=0.7.0,<0.8" },
     { name = "vcrpy", specifier = ">=8.1.1,<9" },
@@ -353,6 +364,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Extract inline table/JSON rendering from `search()` into named helpers, replace a magic `-1` with a constant, and narrow a broad `except Exception` to `requests.RequestException`.

- **cli.py** — `_render_json_output()` and `_render_table_output()` extracted from `search()`; `NO_STATUS_CODE_TIMEOUT = -1` constant added; magic `-1` replaced with named constant in display logic.
- **scraper.py** — `except Exception` narrowed to `except requests.RequestException` in `fetch_site_information`.
- **pyproject.toml / pytest.ini / uv.lock** — `pytest-asyncio` added as dev dependency with `asyncio_mode = auto`.