### PR TITLE
chore: bump pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,23 +8,23 @@ repos:
   - id: check-toml
   - id: check-added-large-files
 - repo: https://github.com/commitizen-tools/commitizen
-  rev: v4.15.1
+  rev: v4.16.5
   hooks:
     - id: commitizen
       stages: [commit-msg]
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: 'v0.15.12'
+  rev: 'v0.16.0'
   hooks:
   - id: ruff-check
     args:
       - '--fix'
   - id: ruff-format
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v2.0.0
+  rev: v2.3.0
   hooks:
   - id: mypy
     additional_dependencies: [types-requests]
 - repo: https://github.com/RobertCraigie/pyright-python
-  rev: v1.1.409
+  rev: v1.1.411
   hooks:
   - id: pyright

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ select = [
 ignore = [
     "E501",
     "PLR0913",
+    "PLR0917",
     "PLR2004",
 ]
 


### PR DESCRIPTION
Bump all four pre-commit hooks to their latest versions:

- commitizen v4.15.1 → v4.16.5
- ruff v0.15.12 → v0.16.0
- mypy v2.0.0 → v2.3.0
- pyright v1.1.409 → v1.1.411

Also ignore `PLR0917` in ruff — the new ruff v0.16.0 flagged the `search()` Click command for having 7 positional arguments, but this is a Click callback where all params are always passed by keyword. `PLR0913` (same family) was already suppressed.