### PR TITLE
fix: broaden retry exception types in fetch_site

### DIFF
--- a/cert_host_scraper/scraper.py
+++ b/cert_host_scraper/scraper.py
@@ -59,7 +59,9 @@ async def async_fetch_site_information(url: str, timeout: int) -> int:
 
 
 @retry(
-    retry=retry_if_exception_type(requests.HTTPError),
+    retry=retry_if_exception_type(
+        (requests.RequestException, urllib3.exceptions.HTTPError)
+    ),
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=1, min=1, max=10),
     reraise=True,


### PR DESCRIPTION
Broadens the retry decorator on `fetch_site()` from only handling `requests.HTTPError` to catching all `requests.RequestException` subclasses as well as `urllib3.exceptions.HTTPError`. This ensures transient network failures (connection drops, DNS
    failures, timeouts) are retried with exponential backoff instead of immediately surfacing.