### PR TITLE
test: add coverage for cli() group callback and pragma on __main__

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,36 +6,53 @@
 
  ```bash
  uv run pytest
+```
+
+With coverage:
+
+```bash
+uv run pytest --cov
  ```
 
- ## Common commands
+ ## Dependency management
+
+ Install/resolve dependencies:
 
  ```bash
- uv sync          # Install/resolve dependencies
- uv run pytest    # Run the test suite
- uv add <pkg>     # Add a dependency
- uv run pre-commit run --all-files  # Run pre-commit hooks on all files
- ```
+ uv sync
+```
 
- ## Committing
-
- This project uses [commitizen](https://commitizen-tools.github.io/commitizen/) (v4) via pre-commit to enforce
- [Conventional Commits](https://www.conventionalcommits.org/) on every commit message.
-
- Commit messages must follow the format:
-
- ```text
- <type>[optional scope]: <description>
-
- [optional body]
- ```
-
- Common types: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`, `ci`, `style`.
-
- You can stage and commit as usual -- commitizen validates the message automatically at commit time.
-
- ### Commit quickly with cz (recommended)
+Add a dependency:
 
  ```bash
- uv run cz commit   # Interactive commit with commitizen prompt
+ uv add <pkg>
  ```
+
+ ## Linting
+
+Lint with pre-commit:
+
+ ```bash
+  uv run pre-commit run --a
+```
+
+ ## Pull requests
+
+Always commit on a branch.
+
+This project uses [commitizen](https://commitizen-tools.github.io/commitizen/) (v4) via pre-commit to enforce
+[Conventional Commits](https://www.conventionalcommits.org/) on every commit message.
+
+Commit messages must follow the format:
+
+```text
+<type>[optional scope]: <description>
+
+[optional body]
+```
+
+Common types: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`, `ci`, `style`.
+
+You can stage and commit as usual -- commitizen validates the message automatically at commit time.
+
+Use `gh` cli for creating the PR.

--- a/cert_host_scraper/cli.py
+++ b/cert_host_scraper/cli.py
@@ -159,5 +159,5 @@ def search(
     render(display)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     cli()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -137,3 +137,14 @@ class TestSearchSuccess(TestCase):
         ]
         output_json = json.loads(result.output)
         self.assertCountEqual(output_json, expected_json)
+
+
+class TestCliGroup(TestCase):
+    """Cover the cli() group callback path via --debug."""
+
+    @patch("cert_host_scraper.cli.fetch_urls")
+    def test_cli_with_debug(self, mock_fetch_urls: Mock):
+        mock_fetch_urls.return_value = []
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--debug", "search", "example.com"])
+        self.assertEqual(result.exit_code, 0)


### PR DESCRIPTION
Closes missing coverage on lines 81-82 (cli --debug path) and line 163 (__main__ guard) in cli.py.

- Invoke the cli group with --debug to exercise the callback body
- Drop redundant process_urls mock, unnecessary uuid4 import
- Exclude if __name__ == '__main__' from coverage via pragma