### PR TITLE
refactor: remove dead code (divide_chunks, search_urls)

### DIFF
--- a/cert_host_scraper/scraper.py
+++ b/cert_host_scraper/scraper.py
@@ -134,18 +134,3 @@ def process_urls(
     return asyncio.run(
         _process_urls(urls, options, batch_size, on_progress=on_progress)
     )
-
-
-def search_urls(
-    search_term: str,
-    options: Options,
-    batch_size: int = 20,
-    *,
-    on_progress: Callable[[], object] | None = None,
-) -> Result:
-    """
-    Fetch certificate log URLs and scrape their status codes.
-    """
-    urls = fetch_urls(search_term, options)
-    scraped = process_urls(urls, options, batch_size, on_progress=on_progress)
-    return Result(scraped)

--- a/cert_host_scraper/utils.py
+++ b/cert_host_scraper/utils.py
@@ -1,13 +1,7 @@
 import re
-from collections.abc import Iterable
 
 
 def strip_url(url: str) -> str:
     url = re.sub(r"https?://", "", url)
     url = re.sub(r"www.", "", url)
     return re.sub(r"/.*", "", url)
-
-
-def divide_chunks(objects: list, size: int) -> Iterable[list[str]]:
-    for i in range(0, len(objects), size):
-        yield objects[i : i + size]

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -113,50 +113,6 @@ class TestProcessUrls(TestCase):
         self.assertEqual(progress.call_count, 2)
 
 
-class TestSearchUrls(TestCase):
-    @patch("cert_host_scraper.scraper.process_urls")
-    @patch("cert_host_scraper.scraper.fetch_urls")
-    def test_search_urls(self, mock_fetch_urls, mock_process_urls):
-        mock_fetch_urls.return_value = [
-            "https://example.com",
-            "https://test.com",
-        ]
-        mock_process_urls.return_value = [
-            scraper.UrlResult("https://example.com", 200),
-            scraper.UrlResult("https://test.com", 404),
-        ]
-
-        options = scraper.Options(timeout=2, clean=True)
-        result = scraper.search_urls("example.com", options)
-
-        self.assertIsInstance(result, scraper.Result)
-        self.assertEqual(len(result.scraped), 2)
-        mock_fetch_urls.assert_called_once_with("example.com", options)
-        mock_process_urls.assert_called_once_with(
-            ["https://example.com", "https://test.com"],
-            options,
-            20,
-            on_progress=None,
-        )
-
-    @patch("cert_host_scraper.scraper.process_urls")
-    @patch("cert_host_scraper.scraper.fetch_urls")
-    def test_search_urls_with_progress(self, mock_fetch_urls, mock_process_urls):
-        mock_fetch_urls.return_value = ["https://example.com"]
-        mock_process_urls.return_value = [
-            scraper.UrlResult("https://example.com", 200),
-        ]
-
-        options = scraper.Options(timeout=2, clean=True)
-        progress = Mock()
-        result = scraper.search_urls("example.com", options, on_progress=progress)
-
-        self.assertIsInstance(result, scraper.Result)
-        mock_process_urls.assert_called_once_with(
-            ["https://example.com"], options, 20, on_progress=progress
-        )
-
-
 class TestResults(TestCase):
     def test_filter_by_status_code(self):
         results = scraper.Result(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from cert_host_scraper.utils import divide_chunks, strip_url
+from cert_host_scraper.utils import strip_url
 
 
 class TestStripUrl(TestCase):
@@ -16,25 +16,3 @@ class TestStripUrl(TestCase):
     def test_strip_path(self):
         self.assertEqual("example.com", strip_url("example.com/"))
         self.assertEqual("example.com", strip_url("example.com/hello"))
-
-
-class TestDivideChunks(TestCase):
-    def test_even_chunks(self):
-        self.assertEqual(
-            list(divide_chunks(["a", "b", "c", "d"], 2)), [["a", "b"], ["c", "d"]]
-        )
-
-    def test_uneven_chunks(self):
-        self.assertEqual(list(divide_chunks(["a", "b", "c"], 2)), [["a", "b"], ["c"]])
-
-    def test_single_element_chunks(self):
-        self.assertEqual(list(divide_chunks(["a", "b", "c"], 1)), [["a"], ["b"], ["c"]])
-
-    def test_chunk_size_larger_than_list(self):
-        self.assertEqual(list(divide_chunks(["a", "b"], 5)), [["a", "b"]])
-
-    def test_empty_list(self):
-        self.assertEqual(list(divide_chunks([], 3)), [])
-
-    def test_chunk_size_one(self):
-        self.assertEqual(list(divide_chunks(["a"], 1)), [["a"]])


### PR DESCRIPTION
## Summary

Removes two pieces of dead production code that were only referenced in tests:

- `divide_chunks()` in `utils.py` — defined, tested, never imported by any production module
- `search_urls()` in `scraper.py` — tested but never called by `cli.py` (the only production entry point)

Also cleans up the orphaned `Iterable` import in `utils.py` and removes the corresponding test classes.

## Type of change

- [ ] feat — new feature
- [ ] fix — bug fix
- [x] refactor — code change that neither fixes a bug nor adds a feature
- [ ] chore — maintenance, tooling, CI, dependency bumps
- [ ] docs — documentation only
- [ ] test — adding or improving tests
- [ ] style — formatting, linting

## Checklist

- [x] Changes are covered by tests
- [ ] `uv run pytest --cov` passes with 100% coverage
- [x] Pre-commit hooks pass (`uv run pre-commit run --all-files`)