### PR TITLE
refactor: make process_urls and filter_by_status_code return Result

### DIFF
--- a/cert_host_scraper/cli.py
+++ b/cert_host_scraper/cli.py
@@ -6,13 +6,12 @@ import click
 from requests import RequestException
 from rich import box
 from rich.console import Console
-from rich.progress import track
+from rich.progress import Progress
 from rich.table import Table
 
 from cert_host_scraper import __version__
 from cert_host_scraper.scraper import (
     Options,
-    Result,
     UrlResult,
     fetch_urls,
     process_urls,
@@ -21,6 +20,8 @@ from cert_host_scraper.utils import strip_url
 
 NO_STATUS_CODE_FILTER = 0
 NO_STATUS_CODE_TIMEOUT = -1
+
+console = Console()
 
 
 def _render_json_output(results: list[UrlResult]) -> str:
@@ -69,7 +70,7 @@ class Output:
 
 
 RENDERERS = {
-    Output.TABLE: lambda results: _render_table_output(results, Console()),
+    Output.TABLE: lambda results: _render_table_output(results, console),
     Output.JSON: lambda results: click.echo(_render_json_output(results)),
 }
 
@@ -138,21 +139,29 @@ def search(
     if show_progress:
         click.echo(f"Found {len(urls)} URLs for {search}")
 
-    progress_iter = (
-        iter(track(range(len(urls)), "Checking URLs")) if show_progress else None
-    )
-    scraped_results = process_urls(
-        urls,
-        options,
-        batch_size,
-        on_progress=lambda: (
-            None if progress_iter is None else next(progress_iter) and None
-        ),
-    )
+    if show_progress:
+        pbar = Progress(console=console, transient=True)
+        task_id = pbar.add_task("Checking URLs", total=len(urls))
+        pbar.start()
 
-    result = Result(scraped_results)
+        try:
+            result = process_urls(
+                urls,
+                options,
+                batch_size,
+                on_progress=lambda: pbar.update(task_id, advance=1),
+            )
+        finally:
+            pbar.stop()
+    else:
+        result = process_urls(
+            urls,
+            options,
+            batch_size,
+        )
+
     if status_code != NO_STATUS_CODE_FILTER:
-        display = result.filter_by_status_code(status_code)
+        display = result.filter_by_status_code(status_code).scraped
     else:
         display = result.scraped
 

--- a/cert_host_scraper/scraper.py
+++ b/cert_host_scraper/scraper.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 from collections.abc import Callable
@@ -37,8 +39,10 @@ class UrlResult:
 class Result:
     scraped: list[UrlResult]
 
-    def filter_by_status_code(self, status_code: int) -> list[UrlResult]:
-        return [result for result in self.scraped if result.status_code == status_code]
+    def filter_by_status_code(self, status_code: int) -> Result:
+        return Result(
+            [result for result in self.scraped if result.status_code == status_code]
+        )
 
 
 def _default_headers() -> dict:
@@ -127,13 +131,14 @@ def process_urls(
     batch_size: int,
     *,
     on_progress: Callable[[], object] | None = None,
-) -> list[UrlResult]:
+) -> Result:
     """
     Process a list of URLs concurrently and return the results.
     """
-    return asyncio.run(
+    scraped = asyncio.run(
         _process_urls(urls, options, batch_size, on_progress=on_progress)
     )
+    return Result(scraped)
 
 
 def search_urls(
@@ -147,5 +152,4 @@ def search_urls(
     Fetch certificate log URLs and scrape their status codes.
     """
     urls = fetch_urls(search_term, options)
-    scraped = process_urls(urls, options, batch_size, on_progress=on_progress)
-    return Result(scraped)
+    return process_urls(urls, options, batch_size, on_progress=on_progress)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,7 @@ from requests import RequestException
 
 from cert_host_scraper import __version__
 from cert_host_scraper.cli import cli, search
-from cert_host_scraper.scraper import UrlResult
+from cert_host_scraper.scraper import Result, UrlResult
 
 
 class TestVersion(TestCase):
@@ -64,11 +64,13 @@ class TestSearchSuccess(TestCase):
         ]
         mock_fetch_urls.return_value = urls
 
-        mock_process_urls.return_value = [
-            UrlResult("https://example-200.com", 200),
-            UrlResult("https://example-404.com", 404),
-            UrlResult("https://example-error.com", -1),
-        ]
+        mock_process_urls.return_value = Result(
+            [
+                UrlResult("https://example-200.com", 200),
+                UrlResult("https://example-404.com", 404),
+                UrlResult("https://example-error.com", -1),
+            ]
+        )
 
         result = runner.invoke(search, ["example.com", "--output", "table"])
 
@@ -93,10 +95,12 @@ class TestSearchSuccess(TestCase):
         urls = ["https://example-200.com", "https://example-404.com"]
         mock_fetch_urls.return_value = urls
 
-        mock_process_urls.return_value = [
-            UrlResult("https://example-200.com", 200),
-            UrlResult("https://example-404.com", 404),
-        ]
+        mock_process_urls.return_value = Result(
+            [
+                UrlResult("https://example-200.com", 200),
+                UrlResult("https://example-404.com", 404),
+            ]
+        )
 
         result = runner.invoke(search, ["example.com", "--output", "json"])
 
@@ -121,11 +125,13 @@ class TestSearchSuccess(TestCase):
         ]
         mock_fetch_urls.return_value = urls
 
-        mock_process_urls.return_value = [
-            UrlResult("https://example-200.com", 200),
-            UrlResult("https://example-404.com", 404),
-            UrlResult("https://example-error.com", -1),
-        ]
+        mock_process_urls.return_value = Result(
+            [
+                UrlResult("https://example-200.com", 200),
+                UrlResult("https://example-404.com", 404),
+                UrlResult("https://example-error.com", -1),
+            ]
+        )
 
         result = runner.invoke(
             search, ["example.com", "--status-code", "200", "--output", "json"]

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -104,12 +104,13 @@ class TestProcessUrls(TestCase):
             scraper.UrlResult(url="http://test.com", status_code=404),
         ]
 
-        results = scraper.process_urls(urls, options, batch_size, on_progress=progress)
-        self.assertEqual(len(results), 2)
-        self.assertEqual(results[0].url, "http://example.com")
-        self.assertEqual(results[0].status_code, 200)
-        self.assertEqual(results[1].url, "http://test.com")
-        self.assertEqual(results[1].status_code, 404)
+        result = scraper.process_urls(urls, options, batch_size, on_progress=progress)
+        self.assertIsInstance(result, scraper.Result)
+        self.assertEqual(len(result.scraped), 2)
+        self.assertEqual(result.scraped[0].url, "http://example.com")
+        self.assertEqual(result.scraped[0].status_code, 200)
+        self.assertEqual(result.scraped[1].url, "http://test.com")
+        self.assertEqual(result.scraped[1].status_code, 404)
         self.assertEqual(progress.call_count, 2)
 
 
@@ -121,10 +122,12 @@ class TestSearchUrls(TestCase):
             "https://example.com",
             "https://test.com",
         ]
-        mock_process_urls.return_value = [
-            scraper.UrlResult("https://example.com", 200),
-            scraper.UrlResult("https://test.com", 404),
-        ]
+        mock_process_urls.return_value = scraper.Result(
+            [
+                scraper.UrlResult("https://example.com", 200),
+                scraper.UrlResult("https://test.com", 404),
+            ]
+        )
 
         options = scraper.Options(timeout=2, clean=True)
         result = scraper.search_urls("example.com", options)
@@ -143,9 +146,11 @@ class TestSearchUrls(TestCase):
     @patch("cert_host_scraper.scraper.fetch_urls")
     def test_search_urls_with_progress(self, mock_fetch_urls, mock_process_urls):
         mock_fetch_urls.return_value = ["https://example.com"]
-        mock_process_urls.return_value = [
-            scraper.UrlResult("https://example.com", 200),
-        ]
+        mock_process_urls.return_value = scraper.Result(
+            [
+                scraper.UrlResult("https://example.com", 200),
+            ]
+        )
 
         options = scraper.Options(timeout=2, clean=True)
         progress = Mock()
@@ -167,6 +172,7 @@ class TestResults(TestCase):
         )
 
         filtered = results.filter_by_status_code(200)
-        self.assertEqual(1, len(filtered))
-        self.assertEqual("https://example-200.org", filtered[0].url)
-        self.assertEqual(200, filtered[0].status_code)
+        self.assertIsInstance(filtered, scraper.Result)
+        self.assertEqual(1, len(filtered.scraped))
+        self.assertEqual("https://example-200.org", filtered.scraped[0].url)
+        self.assertEqual(200, filtered.scraped[0].status_code)


### PR DESCRIPTION
## Summary

Changes the return types of `process_urls` and `Result.filter_by_status_code` to return `Result` instead of `list[UrlResult]`. This makes the `Result` type a more coherent domain abstraction — it's always the unit of return from scraper operations and supports method chaining.

### Changes

- **`process_urls`** now wraps its result in `Result` instead of returning a raw list. `search_urls` simplifies to `return process_urls(...)` since the wrapping is now internal.
- **`Result.filter_by_status_code`** returns `Result` instead of `list[UrlResult]`, making it chainable.
- **`cli.search`** no longer manually constructs `Result(scraped_results)` — `process_urls` already returns one. Access `.scraped` for display.
- Tests updated throughout to assert against `.scraped` where needed and wrap mock return values in `Result`.

## Type of change

- [ ] feat — new feature
- [ ] fix — bug fix
- [x] refactor — code change that neither fixes a bug nor adds a feature
- [ ] chore — maintenance, tooling, CI, dependency bumps
- [ ] docs — documentation only
- [ ] test — adding or improving tests
- [ ] style — formatting, linting

## Checklist

- [x] Changes are covered by tests
- [x] `uv run pytest --cov` passes with 100% coverage
- [x] Pre-commit hooks pass (`uv run pre-commit run --all-files`)