### PR TITLE
fix: double rich progress bar when scanning URLs

### DIFF
--- a/cert_host_scraper/cli.py
+++ b/cert_host_scraper/cli.py
@@ -141,18 +141,14 @@ def search(
         click.echo(f"Found {len(urls)} URLs for {search}")
 
     if show_progress:
-        progress = Progress()
-        task_id = progress.add_task("Checking URLs", total=len(urls))
-        progress.__enter__()
-        try:
+        with Progress() as progress:
+            task_id = progress.add_task("Checking URLs", total=len(urls))
             scraped_results = process_urls(
                 urls,
                 options,
                 batch_size,
                 on_progress=lambda: progress.advance(task_id),
             )
-        finally:
-            progress.__exit__(None, None, None)
     else:
         scraped_results = process_urls(urls, options, batch_size)
 

--- a/cert_host_scraper/cli.py
+++ b/cert_host_scraper/cli.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import logging
 import sys
@@ -6,7 +8,7 @@ import click
 from requests import RequestException
 from rich import box
 from rich.console import Console
-from rich.progress import track
+from rich.progress import Progress
 from rich.table import Table
 
 from cert_host_scraper import __version__
@@ -138,17 +140,21 @@ def search(
     if show_progress:
         click.echo(f"Found {len(urls)} URLs for {search}")
 
-    progress_iter = (
-        iter(track(range(len(urls)), "Checking URLs")) if show_progress else None
-    )
-    scraped_results = process_urls(
-        urls,
-        options,
-        batch_size,
-        on_progress=lambda: (
-            None if progress_iter is None else next(progress_iter) and None
-        ),
-    )
+    if show_progress:
+        progress = Progress()
+        task_id = progress.add_task("Checking URLs", total=len(urls))
+        progress.__enter__()
+        try:
+            scraped_results = process_urls(
+                urls,
+                options,
+                batch_size,
+                on_progress=lambda: progress.advance(task_id),
+            )
+        finally:
+            progress.__exit__(None, None, None)
+    else:
+        scraped_results = process_urls(urls, options, batch_size)
 
     result = Result(scraped_results)
     if status_code != NO_STATUS_CODE_FILTER:

--- a/cert_host_scraper/scraper.py
+++ b/cert_host_scraper/scraper.py
@@ -114,9 +114,9 @@ async def _process_urls(
     async def fetch(url: str) -> UrlResult:
         async with sem:
             result = await validate_url(url, options)
-            if on_progress:
-                on_progress()
-            return result
+        if on_progress:
+            on_progress()
+        return result
 
     return await asyncio.gather(*[fetch(u) for u in urls])
 


### PR DESCRIPTION
Replace track() with an explicit Progress context manager so the
live display is fully stopped before the result table is rendered.

The track() helper ties its lifecycle to the iterator — when the
range is exhausted the context manager exits but the display thread
may still render a final frame, causing the progress bar to appear
a second time after the table output.
