### PR TITLE
chore: use uv run in mise test tasks, add clean task

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -7,8 +7,12 @@ postinstall = "pre-commit install && pre-commit install --hook-type commit-msg -
 
 [tasks.test]
 description = "Run tests"
-run = "pytest"
+run = "uv run pytest"
 
 [tasks.test-record]
 description = "Run tests with recording"
-run = "VCR_RECORD_MODE=all pytest"
+run = "VCR_RECORD_MODE=all uv run pytest"
+
+[tasks.clean]
+description = "Remove tool and test cache files"
+run = "find . -maxdepth 3 \\( -name '__pycache__' -o -name '.pytest_cache' -o -name '.ruff_cache' -o -name '.mypy_cache' \\) -exec rm -rf {} + && rm -f .coverage"


### PR DESCRIPTION
## Summary

Wrap mise task commands (`test`, `test-record`) with `uv run` so they work consistently with the project's uv-based toolchain. Also add a `clean` task to remove cache files (`__pycache__`, `.pytest_cache`, `.ruff_cache`, `.mypy_cache`, `.coverage`).

## Type of change

- [x] chore — maintenance, tooling, CI, dependency bumps